### PR TITLE
Add PDF page extraction utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ const result = await extractPDFContent("file.pdf", "./out");
 console.log(result.pages.length);
 ```
 
+## `extractPagesFromPDF`
+
+Creates a new PDF containing only the pages you specify.
+
+```ts
+import { extractPagesFromPDF } from "@baiq/document-parser";
+const outPath = await extractPagesFromPDF("file.pdf", [1, 3]);
+console.log(outPath);
+```
+
 ## `extractEPUBContent`
 
 Parses an EPUB archive to gather paragraphs and referenced images from each

--- a/deno.json
+++ b/deno.json
@@ -9,6 +9,7 @@
     "@std/path": "jsr:@std/path@^1.0.9",
     "fast-xml-parser": "npm:fast-xml-parser@^5.2.3",
     "jszip": "npm:jszip@^3.10.1",
-    "mammoth": "npm:mammoth@^1.9.0"
+    "mammoth": "npm:mammoth@^1.9.0",
+    "pdf-lib": "npm:pdf-lib@^1.17.1"
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -4,4 +4,5 @@ export { extractEPUBContent } from "./epub-extractor/mod.ts";
 export type { EPUBExtractionResult } from "./epub-extractor/mod.ts";
 export { extractDOCXContent } from "./docx-extractor/mod.ts";
 export type { DOCXExtractionResult } from "./docx-extractor/mod.ts";
+export { extractPagesFromPDF } from "./pdf-page-extractor/mod.ts";
 export type { PageContent } from "./types.ts";

--- a/pdf-page-extractor/mod.ts
+++ b/pdf-page-extractor/mod.ts
@@ -1,0 +1,28 @@
+import { PDFDocument } from "pdf-lib";
+
+/**
+ * Extract specific pages from a PDF file.
+ *
+ * @param pdfPath Path to the source PDF.
+ * @param pages Array of 1-based page numbers to include in the new PDF.
+ * @returns Path to a temporary PDF file containing the selected pages.
+ */
+export async function extractPagesFromPDF(
+  pdfPath: string,
+  pages: number[],
+): Promise<string> {
+  const bytes = await Deno.readFile(pdfPath);
+  const src = await PDFDocument.load(bytes);
+  const out = await PDFDocument.create();
+
+  const pageCount = src.getPageCount();
+  for (const p of pages) {
+    if (p < 1 || p > pageCount) continue;
+    const [copied] = await out.copyPages(src, [p - 1]);
+    out.addPage(copied);
+  }
+
+  const tmp = await Deno.makeTempFile({ suffix: ".pdf" });
+  await Deno.writeFile(tmp, await out.save());
+  return tmp;
+}


### PR DESCRIPTION
## Summary
- add pdf page extraction module using `pdf-lib`
- export `extractPagesFromPDF`
- document new function in README
- add `pdf-lib` to imports

## Testing
- `deno fmt --check` *(fails: Found 4 not formatted files)*

------
https://chatgpt.com/codex/tasks/task_b_683e99807f088330b70480bb499bfe2c