### PR TITLE
Add Deno test for page extractor

### DIFF
--- a/tests/assets/example.pdf
+++ b/tests/assets/example.pdf
@@ -1,0 +1,54 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Count 3 /Kids [3 0 R 4 0 R 5 0 R] >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 6 0 R >> >> /MediaBox [0 0 612 792] /Contents 7 0 R >>
+endobj
+4 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 6 0 R >> >> /MediaBox [0 0 612 792] /Contents 8 0 R >>
+endobj
+5 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 6 0 R >> >> /MediaBox [0 0 612 792] /Contents 9 0 R >>
+endobj
+6 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+7 0 obj
+<< /Length 52 >>
+stream
+BT /F1 24 Tf 100 700 Td (Hello page1) Tj ET
+endstream
+endobj
+8 0 obj
+<< /Length 52 >>
+stream
+BT /F1 24 Tf 100 700 Td (Hello page2) Tj ET
+endstream
+endobj
+9 0 obj
+<< /Length 52 >>
+stream
+BT /F1 24 Tf 100 700 Td (Hello page3) Tj ET
+endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000127 00000 n 
+0000000253 00000 n 
+0000000379 00000 n 
+0000000505 00000 n 
+0000000575 00000 n 
+0000000668 00000 n 
+0000000761 00000 n 
+trailer
+<< /Root 1 0 R /Size 10 >>
+startxref
+854
+%%EOF

--- a/tests/pdf-page-extractor.test.ts
+++ b/tests/pdf-page-extractor.test.ts
@@ -1,0 +1,15 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1";
+import { fromFileUrl } from "@std/path";
+import { exists } from "@std/fs";
+import { extractPagesFromPDF } from "../pdf-page-extractor/mod.ts";
+
+const EXAMPLE_PDF = fromFileUrl(new URL("./assets/example.pdf", import.meta.url));
+
+Deno.test("extracts specified pages", async () => {
+  const output = await extractPagesFromPDF(EXAMPLE_PDF, [1, 3]);
+  assert(await exists(output), "output file should exist");
+  const text = await Deno.readTextFile(output);
+  const pageCount = (text.match(/\/Type \/Page/g) ?? []).length;
+  assertEquals(pageCount, 2);
+  await Deno.remove(output);
+});


### PR DESCRIPTION
## Summary
- add sample PDF for tests
- add a basic unit test covering pdf-page-extractor

## Testing
- `deno test -A` *(fails: JSR package manifest for '@std/assert' failed to load)*

------
https://chatgpt.com/codex/tasks/task_b_683e9b7e77088330b82cea6240a78edc