### PR TITLE
feat: add DOCX page extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ import { extractPagesFromPDF } from "@baiq/document-parser";
 const outPath = await extractPagesFromPDF("file.pdf", [1, 3]);
 console.log(outPath);
 ```
+
 ## `extractPagesFromDOCX`
 
-Creates a new DOCX containing only the pages separated by explicit page breaks.
+Converts a DOCX file to PDF using the `soffice` CLI and returns a new PDF
+containing only the pages you specify.
 
 ```ts
 import { extractPagesFromDOCX } from "@baiq/document-parser";
@@ -71,6 +73,7 @@ Images are written to the provided output directory, and the returned paths
 reference those files.
 
 ## Examples
+
 See the `examples` directory for usage examples and a simple HTTP service that
 demonstrates how to use these modules in practice.
 
@@ -78,7 +81,6 @@ demonstrates how to use these modules in practice.
 
 This repository also includes an example HTTP service that uses these modules to
 extract content from files stored on Google Cloud Storage. The service accepts a
-`POST /extract` request with a JSON body containing a `fileUrl` pointing to a GCS
-object. It downloads the file, extracts its contents, and re-uploads any extracted
-images, returning a JSON response with signed URLs.
-
+`POST /extract` request with a JSON body containing a `fileUrl` pointing to a
+GCS object. It downloads the file, extracts its contents, and re-uploads any
+extracted images, returning a JSON response with signed URLs.

--- a/docx-page-extractor/mod.ts
+++ b/docx-page-extractor/mod.ts
@@ -1,0 +1,61 @@
+import { basename, dirname, extname, join } from "@std/path";
+import { extractPagesFromPDF } from "../pdf-page-extractor/mod.ts";
+
+/**
+ * Convert a DOCX file to PDF using the `soffice` CLI.
+ *
+ * @param docxPath Path to the source DOCX file.
+ * @returns Path to the generated PDF.
+ */
+async function defaultConvert(docxPath: string): Promise<string> {
+  const outDir = await Deno.makeTempDir();
+  const cmd = new Deno.Command("soffice", {
+    args: ["--headless", "--convert-to", "pdf", "--outdir", outDir, docxPath],
+    stdout: "null",
+    stderr: "null",
+  });
+  const { code } = await cmd.output();
+  if (code !== 0) {
+    throw new Error("Failed to convert DOCX to PDF using soffice");
+  }
+  const pdfName = `${basename(docxPath, extname(docxPath))}.pdf`;
+  return join(outDir, pdfName);
+}
+
+export interface ExtractDocxOptions {
+  /** Custom conversion function. Defaults to using `soffice`. */
+  convert?: (docxPath: string) => Promise<string>;
+}
+
+/**
+ * Extract specific pages from a DOCX file.
+ *
+ * This helper converts the DOCX to PDF using a CLI command and then
+ * delegates to {@link extractPagesFromPDF}.
+ *
+ * @param docxPath Path to the DOCX file.
+ * @param pages    1-based page numbers to include.
+ * @param options  Optional conversion override.
+ * @returns Path to a temporary PDF containing the selected pages.
+ */
+export async function extractPagesFromDOCX(
+  docxPath: string,
+  pages: number[],
+  options: ExtractDocxOptions = {},
+): Promise<string> {
+  const convert = options.convert ?? defaultConvert;
+  const pdfPath = await convert(docxPath);
+  const outPath = await extractPagesFromPDF(pdfPath, pages);
+
+  // clean up if default converter was used
+  if (options.convert === undefined) {
+    try {
+      await Deno.remove(pdfPath);
+      await Deno.remove(dirname(pdfPath), { recursive: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+
+  return outPath;
+}

--- a/examples/docx-page-extractor/README.md
+++ b/examples/docx-page-extractor/README.md
@@ -1,0 +1,12 @@
+# DOCX Page Extractor Example
+
+This example shows how to use `extractPagesFromDOCX` to convert a DOCX file to
+PDF and keep only specific pages.
+
+Run the script with the required permissions:
+
+```bash
+$ deno run --allow-read --allow-write --allow-run main.ts <file.docx> <page> [page...]
+```
+
+The script prints the path to the generated PDF.

--- a/examples/docx-page-extractor/deno.json
+++ b/examples/docx-page-extractor/deno.json
@@ -1,0 +1,9 @@
+{
+  "tasks": {
+    "run": "deno run --allow-read --allow-write --allow-run main.ts"
+  },
+  "imports": {
+    "@baiq/document-parser": "jsr:@baiq/document-parser@^0.1.1",
+    "@std/flags": "jsr:@std/flags@^1.0.0"
+  }
+}

--- a/examples/docx-page-extractor/main.ts
+++ b/examples/docx-page-extractor/main.ts
@@ -1,0 +1,16 @@
+import { parse } from "@std/flags";
+import { extractPagesFromDOCX } from "@baiq/document-parser";
+
+const { _: args } = parse(Deno.args);
+if (args.length < 2) {
+  console.log(
+    "Usage: deno run --allow-read --allow-write --allow-run main.ts <file.docx> <page> [page...]",
+  );
+  Deno.exit(1);
+}
+
+const [file, ...pageArgs] = args;
+const pages = pageArgs.map((p) => Number(p));
+
+const out = await extractPagesFromDOCX(String(file), pages);
+console.log("Created:", out);

--- a/mod.ts
+++ b/mod.ts
@@ -2,4 +2,5 @@ export { extractPDFContent } from "./pdf-extractor/mod.ts";
 export { extractEPUBContent } from "./epub-extractor/mod.ts";
 export { extractDOCXContent } from "./docx-extractor/mod.ts";
 export { extractPagesFromPDF } from "./pdf-page-extractor/mod.ts";
+export { extractPagesFromDOCX } from "./docx-page-extractor/mod.ts";
 export type { DocExtractionResult, PageContent } from "./types.ts";

--- a/tests/docx-page-extractor.test.ts
+++ b/tests/docx-page-extractor.test.ts
@@ -1,0 +1,27 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1";
+import { fromFileUrl } from "@std/path";
+import { exists } from "@std/fs";
+import { PDFDocument } from "pdf-lib";
+import { extractPagesFromDOCX } from "../docx-page-extractor/mod.ts";
+
+const EXAMPLE_DOCX = fromFileUrl(
+  new URL("./assets/example.docx", import.meta.url),
+);
+const EXAMPLE_PDF = fromFileUrl(
+  new URL("./assets/example.pdf", import.meta.url),
+);
+
+Deno.test("extracts pages from DOCX via PDF", async () => {
+  // stub converter to avoid external soffice dependency
+  const output = await extractPagesFromDOCX(EXAMPLE_DOCX, [2], {
+    convert: async () => EXAMPLE_PDF,
+  });
+
+  assert(await exists(output), "output file should exist");
+
+  const bytes = await Deno.readFile(output);
+  const doc = await PDFDocument.load(bytes);
+  assertEquals(doc.getPageCount(), 1);
+
+  await Deno.remove(output);
+});


### PR DESCRIPTION
Adds a module that converts DOCX files to PDF using `soffice` and extracts chosen pages via the existing PDF page extractor.
Includes a new test and runnable example.

------
https://chatgpt.com/codex/tasks/task_b_683eaea4ac848330a33ec7a8f4b19b7b